### PR TITLE
A little more readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import '@github/custom-element-element'
 <custom-element></custom-element>
 ```
 
-## Browser Support
+## Browser support
 
 - Chrome 54+
 - Safari 10.1+

--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ import '@github/custom-element-element'
 
 ## Browser support
 
-- Chrome 54+
-- Safari 10.1+
-- Firefox (Custom Element polyfill required)
-- Internet Explorer 11+ (Custom Element polyfill required)
-- Microsoft Edge (Custom Element polyfill required)
+Browsers without native [custom element support][support] require a [polyfill][].
+
+- Chrome
+- Firefox
+- Safari
+- Internet Explorer 11
+- Microsoft Edge
+
+[support]: https://caniuse.com/#feat=custom-elementsv1
+[polyfill]: https://github.com/webcomponents/custom-elements

--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ Browsers without native [custom element support][support] require a [polyfill][]
 
 [support]: https://caniuse.com/#feat=custom-elementsv1
 [polyfill]: https://github.com/webcomponents/custom-elements
+
+## Development
+
+```
+npm install
+npm test
+```
+
+## License
+
+Distributed under the MIT license. See LICENSE for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@github/custom-element-element",
   "version": "0.0.1",
+  "description": "Boilerplate for creating a custom element.",
   "main": "dist/index-umd.js",
   "module": "dist/index.esm.js",
   "license": "MIT",


### PR DESCRIPTION
Link to a custom element polyfill and browser support pages so we don't need to maintain a list of browsers and caveats in each element's readme file.