### PR TITLE
Set the correct script tags for development and production

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -10,5 +10,5 @@
   <!-- Development script, uncomment when running locally and comment out the production one -->
   <!-- <script src="../dist/index.umd.js"></script> -->
   <!-- Production script -->
-  <script src="https://unpkg.com/@github/auto-complete-element@latest/dist/index.umd.js"></script></body>
+  <script src="https://unpkg.com/@github/custom-element-boilerplate@latest/dist/index.umd.js"></script></body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,8 +7,9 @@
 <body>
   <custom-element></custom-element>
   
-  <!-- Development script, uncomment when running locally and comment out the production one -->
+  <!-- GitHub Pages development script, uncomment when running example locally and comment out the production one -->
   <!-- <script src="../dist/index.umd.js"></script> -->
-  <!-- Production script -->
+  
+  <!-- GitHub Pages demo script -->
   <script src="https://unpkg.com/@github/custom-element-boilerplate@latest/dist/index.umd.js"></script></body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,6 +6,9 @@
 </head>
 <body>
   <custom-element></custom-element>
-  <script type="module" src="../index.js"></script>
-</body>
+  
+  <!-- Development script, uncomment when running locally and comment out the production one -->
+  <!-- <script src="../dist/index.umd.js"></script> -->
+  <!-- Production script -->
+  <script src="https://unpkg.com/@github/auto-complete-element@latest/dist/index.umd.js"></script></body>
 </html>


### PR DESCRIPTION
This seems to be how we do it in other custom elements, see [`<auto-complete>`](https://github.com/github/auto-complete-element/blob/master/examples/index.html#L49-L50).