### PR TITLE
Use `github-lint` command instead of `eslint` and `flow` commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "eslint index.js test/ && flow check",
+    "lint": "github-lint",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "build-umd": "BABEL_ENV=umd babel index.js -o dist/index.umd.js",
     "build-esm": "BABEL_ENV=esm babel index.js -o dist/index.esm.js",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,1 +1,2 @@
+/* @flow strict */
 module.exports = require('eslint-plugin-github/prettier.config')


### PR DESCRIPTION
The [github-lint binary](https://github.com/github/eslint-plugin-github/blob/master/bin/github-lint.js) adds flags and checks based on the project.