### PR TITLE
Load bundles based on what environment the user is in

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -7,9 +7,14 @@
 <body>
   <custom-element></custom-element>
   
-  <!-- GitHub Pages development script, uncomment when running example locally and comment out the production one -->
-  <!-- <script src="../dist/index.umd.js"></script> -->
-  
-  <!-- GitHub Pages demo script -->
-  <script src="https://unpkg.com/@github/custom-element-boilerplate@latest/dist/index.umd.js"></script></body>
+  <script>
+    const script = document.createElement('script')
+    if (window.location.hostname.endsWith('github.io')) {
+      script.src = "https://unpkg.com/@github/custom-element-boilerplate@latest/dist/index.umd.js"
+    } else {
+      script.src = "../dist/index.umd.js"
+    }
+    document.body.appendChild(script)
+  </script>
+</body>
 </html>


### PR DESCRIPTION
I keep messing this up and accidentally pushing those changes to PRs. What do you think about taking the manual editing of comments out of the equation and just load the correct script for the correct environment?

When running locally, you'll get the locally build bundle and when on gh-pages we'll load the unpkg one.