### PR TITLE
Add TS window declaration for CustomElementElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,7 @@
 export default class CustomElementElement extends HTMLElement { }
+
+declare global {
+  interface Window {
+    CustomElementElement: typeof CustomElementElement
+  }
+}


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `CustomElementElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58