### PR TITLE
Run tests in a headless firefox as well

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4058,6 +4058,12 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+      "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4230,6 +4236,15 @@
       "requires": {
         "fs-access": "^1.0.0",
         "which": "^1.2.1"
+      }
+    },
+    "karma-firefox-launcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.2.0.tgz",
+      "integrity": "sha512-j9Zp8M8+VLq1nI/5xZGfzeaEPtGQ/vk3G+Y8vpmFWLvKLNZ2TDjD6cu2dUu7lDbu1HXNgatsAX4jgCZTkR9qhQ==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^2.1.0"
       }
     },
     "karma-mocha": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "karma": "^4.1.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "mocha": "^6.1.4"

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -6,7 +6,7 @@ module.exports = function(config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadless', 'FirefoxHeadless'],
     autoWatch: false,
     singleRun: true,
     concurrency: Infinity


### PR DESCRIPTION
Pulling this up to the boilerplate from https://github.com/github/include-fragment-element/pull/53.

---

Runs all the tests in Firefox as well as Chrome.

One thing to consider is wether or not we should assume that whoever is running these tests has all these browsers installed as we add more to the list.

We are assume that they have Chrome installed so it's maybe not a huge assumption to make that they have Firefox installed as well but if we were to add Safari or Edge then the question isn't as easy to answer.