### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Node CI
 on: [push]
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As part of the organization's transition to default read-only permissions for the GITHUB_TOKEN, this pull request addresses a missing permission in the workflow that triggered a code scanning alert.

This PR explicitly adds the required read permissions to align with the default read only permission and is part of a larger effort for this OKR https://github.com/github/security-services/issues/455

Potential fixes for 2 code scanning alerts from the [Copilot AutoFix: Missing Permissions in Workflows](https://github.com/orgs/github/security/campaigns/20) security campaign:
- https://github.com/github/custom-element-boilerplate/security/code-scanning/2
To address the CodeQL warning and follow security best practices, an explicit `permissions` block should be added specifying the minimal required privileges. Since the shown job only checks out code and publishes to npm (with authentication via `NODE_AUTH_TOKEN`), the only required privilege for the GITHUB_TOKEN is likely `contents: read`. This fix involves adding a `permissions:` block at the workflow root (to cover all jobs) or within the specific job that needs it. The best location is the top of the file, after the name and before `on:`, or just after `on:` and before `jobs:`.

  **Implementation Steps:**  
  - Insert the following block near the top of `.github/workflows/publish.yml` (after the `name:` and before `on:` or directly after `on:`):

  ```yaml
  permissions:
  contents: read
  ```

  - No other changes are necessary unless further job steps (not shown) require additional permissions.
  


- https://github.com/github/custom-element-boilerplate/security/code-scanning/1
The best way to fix the issue is to add a `permissions` block to the workflow or the specific job(s) within the workflow. Since the job appears to only be building and testing code (checkout and setup-node, then npm commands), it does not require write access to repository resources, so setting `contents: read` at the job level is sufficient and aligns with GitHub's recommended minimum. This can be done by adding a `permissions:` block under the `build:` job, above `runs-on: macos-latest`.

  No new methods or imports are required; this is a YAML structural edit.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
